### PR TITLE
piper-tts workaround for setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ aiVoice.*
 curlResponse.txt
 response.txt
 chatHistory.txt
+
+# MacOS Workaround for piper-tts and piper-phonemize version issue
+piper-phonemize

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Third, have an installation of [pipx](https://github.com/pypa/pipx?tab=readme-ov
 
 ### Build & Ship
 1. Install piper-tts via `pipx`, or into a venv. `pipx` is certainly more convenient.
+   * There are some issues with a recent swap on semantic versioning for piper-tts. A temp workaround has been found thanks to nickolay under [piper-phonemize issue-14](https://github.com/rhasspy/piper-phonemize/issues/14#issuecomment-1837289540)
 
-1. Kick off the building of the various components with
+2. Kick off the building of the various components with
 ```sh
 ./setup.sh;
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ The final output of this will be a .wav file, and you can trivially use whatever
 
 That's it!
 
+## Licensing
+whisper.cpp, piper, and llama.cpp are licensed under MIT license.
+
+The Echo mascot image was originally generated with the assistance of DALL·E 3. It was further edited by @JohnnySn0w.
 
 
 ## Bugs

--- a/install_piper.sh
+++ b/install_piper.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Automated workaround for piper-tts and piper-phonemize install
+# TODO: Fix for windows
+
+# Clone project
+git clone git@github.com:rhasspy/piper-phonemize.git piper-phonemize
+cd piper-phonemize
+# Checkout (tag: 2023.11.14-4, Date:   Tue Nov 14 11:54:34 2023 -0600)
+git checkout fccd4f335aa68ac0b72600822f34d84363daa2bf -b temp
+# Build piper-phonemize
+make clean; make
+
+# Link piper-phonemize dependencies to avoid dyld[82606]: Library not loaded: @rpath/libpiper_phonemize.1.dylib
+# TODO: Get OS version to use cd for Windows instead of pwd
+export DYLD_LIBRARY_PATH=`pwd`/install/lib/
+
+# Test command for lib linking
+# echo "testing one two three" | ./install/bin/piper_phonemize -l en-us --espeak-data ./install/share/espeak-ng-data/
+
+# Create ven in root of project
+python3 -m venv ../venv
+# Activate virtual env and update pip
+source ../venv/bin/activate; pip install -U pip
+
+# Tweak C++ headers to update __version__ for piper-phonemize
+patch -p1 <<EOF
+--- a/setup.py
++++ b/setup.py
+@@ -9 +9 @@ _DIR = Path(__file__).parent
+-_ESPEAK_DIR = _DIR / "espeak-ng" / "build"
++_ESPEAK_DIR = _DIR / "install"
+@@ -13 +13 @@ _ONNXRUNTIME_DIR = _LIB_DIR / "onnxruntime"
+-__version__ = "1.2.0"
++__version__ = "1.1.0"
+EOF
+
+# Install temp local version of piper-phonemize to virtual environment
+pip install .
+# Copy espeak-ng-data from build to virtual env
+# TODO: Fix determining correct python major.minor
+cp -rp ./install/share/espeak-ng-data ../venv/lib/python3.11/site-packages/piper_phonemize/espeak-ng-data
+
+pip install piper-tts
+
+# Example of testing piper-tts & play file!
+# echo 'Welcome to the world of speech synthesis!' | piper --model en_US-lessac-medium --output_file welcome.wav
+# afplay welcome.wav


### PR DESCRIPTION
Adding simple script to clone, install, and patch piper-phonemize so we can install of piper-tts workaround [piper-phonemize issue #14](https://github.com/rhasspy/piper-phonemize/issues/14)